### PR TITLE
Missing tr() for four descriptions in keyboard shortcuts window

### DIFF
--- a/src/MainUI/BookBrowser.cpp
+++ b/src/MainUI/BookBrowser.cpp
@@ -1419,14 +1419,14 @@ void BookBrowser::CreateContextMenuActions()
     sm->registerAction(this, m_CopyHTML, "MainWindow.BookBrowser.CopyHTML");
     m_Delete->setShortcut(QKeySequence::Delete);
     m_Merge->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_M));
-    m_Merge->setToolTip("Merge with previous file, or merge multiple files into one.");
+    m_Merge->setToolTip(tr("Merge with previous file, or merge multiple files into one."));
     sm->registerAction(this, m_Merge, "MainWindow.BookBrowser.Merge");
     m_Rename->setShortcut(QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_R));
-    m_Rename->setToolTip("Rename selected file(s)");
+    m_Rename->setToolTip(tr("Rename selected file(s)"));
     sm->registerAction(this, m_Rename, "MainWindow.BookBrowser.Rename");
-    m_LinkStylesheets->setToolTip("Link Stylesheets to selected file(s).");
+    m_LinkStylesheets->setToolTip(tr("Link Stylesheets to selected file(s)."));
     sm->registerAction(this, m_LinkStylesheets, "MainWindow.BookBrowser.LinkStylesheets");
-    m_AddSemantics->setToolTip("Add Semantics to selected file(s).");
+    m_AddSemantics->setToolTip(tr("Add Semantics to selected file(s)."));
     sm->registerAction(this, m_AddSemantics, "MainWindow.BookBrowser.AddSemantics");
     // Has to be added to the book browser itself as well
     // for the keyboard shortcut to work.


### PR DESCRIPTION
Fixes #346 [Missing translation strings](https://github.com/Sigil-Ebook/Sigil/issues/346)