### PR TITLE
Fix for missing translation in context menu...

### DIFF
--- a/src/Misc/FindReplaceQLineEdit.h
+++ b/src/Misc/FindReplaceQLineEdit.h
@@ -33,6 +33,7 @@ class QSignalMapper;
 
 class FindReplaceQLineEdit : public QLineEdit
 {
+    Q_OBJECT
 
 public:
     FindReplaceQLineEdit(QWidget *parent = 0);


### PR DESCRIPTION
...for Find field

Fixes #346 [Missing translation strings](https://github.com/Sigil-Ebook/Sigil/issues/346)